### PR TITLE
docs/hosts: remove hint, discuss replit / heroku

### DIFF
--- a/docs/resources/hostingproviders.md
+++ b/docs/resources/hostingproviders.md
@@ -12,8 +12,17 @@ Here you can find a bunch of hosting providers that are useful for the installat
 - [Linode](https://www.linode.com/)
 - [Vultr](https://www.vultr.com/)
 
-:::caution
-You cannot host YAGPDB on Replit/Heroku etc. platforms.
-:::
+## Replit / Heroku
+
+Though technically possible, we don't recommend hosting YAGPDB on the free tiers of repl.it and Heroku.
+
+This is due to the nature of how repl.it sets up their environment, as they will not give you root access, which is in general
+necessary to install the dependencies.
+Furthermore, your data won't be persistent, which means you'll have to use external (possibly paid) services, and that
+kind of defeats the purpose of using a free hosting provider.
+
+Heroku is similar, as they wipe your data on a daily basis with the free plan. Additionally, their command line interface
+is rather lackluster for (advanced) self-hosters and maintenance purposes.
+
 
 Have recommendation for host? Create [Pull request](https://github.com/JantsoP/hostyagpdb/pulls)


### PR DESCRIPTION
Generally speaking, it is technically possible to host YAGPDB on repl.it
and/or Heroku, but it is strongly discouraged.

Their free plans do not grant the necessary data integrity and access
which are implicitly required to pull up a YAGPDB instance and maintain
it.
This commit adds a brief discussion of the ins and outs of using such
free services, and specifically mentions the issue regarding those free
plans.