### PR TITLE
docs/issues: get rid of `/etc/environment` advice

### DIFF
--- a/docs/selfhost/issues.md
+++ b/docs/selfhost/issues.md
@@ -12,11 +12,8 @@ If you get this error:
 
 ```error="Did not set required config option: \"yagpdb.clientid\" (YAGPDB_CLIENTID as env var)"```
 
-**Using ```/etc/environment```:**  
-If you have put your [env variables](https://raw.githubusercontent.com/botlabs-gg/yagpdb/master/cmd/yagpdb/sampleenvfile) inside of ```/etc/environment```, simply log out of your shell and log back in. Then try to start YAGPDB as you would normally. However, we reccommend that you move your env variables to ```~/.profile```. Learn how to do so [here](/selfhost/selfhostyag).
-
-**Using ```~/.profile:```**  
-If you are storing your [env variables](https://raw.githubusercontent.com/botlabs-gg/yagpdb/master/cmd/yagpdb/sampleenvfile) inside of ```~/.profile```, ensure that you're starting YAGPDB with the same user. Example if you start yag with sudo - you must store your env variables as the root user. As a work around you can use the following command:  
+**Using ```~/.profile:```**
+If you are storing your [env variables](https://raw.githubusercontent.com/botlabs-gg/yagpdb/master/cmd/yagpdb/sampleenvfile) inside of ```~/.profile```, ensure that you're starting YAGPDB with the same user. Example if you start yag with sudo - you must store your env variables as the root user. As a work around you can use the following command:
 ```sudo -E ./yagpdb -all```
 
 ---
@@ -38,5 +35,5 @@ Your dashboard should now be accessible by using ```http://example.com```.
 
 ## Know of any other common issues?
 
-Do you know any common issues that occur often or are enquired about all the time?  
+Do you know any common issues that occur often or are enquired about all the time?
 Send them my way via [GitHub Pull request](https://github.com/JantsoP/hostyagpdb/pulls).


### PR DESCRIPTION
Using `/etc/environment` for anything you absolutely do not want to
expose to other users is the worst idea ever.

Though it is pointed out that this is **not recommended**, it is better
to outright remove this, as *some people* will gleefully gloss over the
last sentence.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>